### PR TITLE
Switch to the go-ble fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ currantlabs(/paypal's) gatt implementation.
 
 ## Setup
 
-See the [gatt docs](https://godoc.org/github.com/currantlabs/gatt#hdr-SETUP)
+See the [gatt docs](https://godoc.org/github.com/go-ble/gatt#hdr-SETUP)
 for the Bluetooth requirements/setup.
 
 ## Examples

--- a/device.go
+++ b/device.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"runtime"
 
-	"github.com/currantlabs/ble"
+	"github.com/go-ble/ble"
 )
 
 // NewDefaultDevice is platform specific, see ble documentation for details.

--- a/device_darwin.go
+++ b/device_darwin.go
@@ -1,8 +1,8 @@
 package golaunch
 
 import (
-	"github.com/currantlabs/ble"
-	"github.com/currantlabs/ble/darwin"
+	"github.com/go-ble/ble"
+	"github.com/go-ble/ble/darwin"
 )
 
 // NewDefaultDevice is platform specific, see ble documentation for details.

--- a/device_linux.go
+++ b/device_linux.go
@@ -1,8 +1,8 @@
 package golaunch
 
 import (
-	"github.com/currantlabs/ble"
-	"github.com/currantlabs/ble/linux"
+	"github.com/go-ble/ble"
+	"github.com/go-ble/ble/linux"
 )
 
 // NewDefaultDevice is platform specific, see ble documentation for details.

--- a/launch.go
+++ b/launch.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/currantlabs/ble"
+	"github.com/go-ble/ble"
 )
 
 var (


### PR DESCRIPTION
The go-ble/ble fork seems to be more maintained and contains patches for MacOS High Sierra.